### PR TITLE
Version 3.2.0 fileset released to ZC for publishing

### DIFF
--- a/Installation files/YOUR_ADMIN/includes/installers/dpu/3_2_0.php
+++ b/Installation files/YOUR_ADMIN/includes/installers/dpu/3_2_0.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * @package functions
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
+ * @copyright Portions Copyright 2003 osCommerce
+ * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
+ * @version $Id: mc12345678 thanks to bislewl 6/9/2015
+ */
+/*
+  V3.2.0, What changed:
+  - Identified this version as 3.2.0 because 1) this update provided significant new functionality and modified/provided
+      new database features and 2) 3.1.0 had previously been identified in the github path/history and did not want to
+      cause undo confusion.
+  - Commented out code that performed no operation/action.
+  - Added an update to the customer's latest page when using an ajax style call to improve display of
+      information on the who's online admin page.
+  - Added a method to update price text to represent when none and less than all attributes have been selected.
+  - Added DPU_ATTRIBUTES_MULTI_PRICE_TEXT to be able to control which of the pretext(s) to allow to show.
+  - Added a variable to be able to update/display the text before the first price when price includes
+      a special and/or a sale.
+  - Added ability to update what is known as the normalprice which is the price/value that is crossed out when there
+      is a sale or other special.
+  - Added stock quantity update capability which incorporates the possibility of operating with ZC 1.5.x and
+      control how the information is replaces other content.  Guidance for display modifications provided in readme.txt.
+  - Corrected use of float casting to use code published in ZC 1.5.6 to support strict server mode.
+  - Reworked code to better account and control sub-functional area execution.
+  - Removed single quotes from SQL queries that included casted integers to minimize further processing.
+  - Expanded attribute text switching to more than product priced by attribute such that should apply to
+      product that have attributes that affect the base price.
+  - Corrected price display and determination to include pricing associated with text (word and/or letter pricing, etc...)
+  - Updated javascript side to use exactly equal to instead of loosely comparing two values (in a majority of examples.
+  - Switched javascript calls to use dot notation where able.
+  - Added a fallback attempt for collecting/setting JSON response if responseJSON is empty but a non-fault responseText
+      is provided.
+  - Moved javascript variable declaration out of most function calls.
+  - Corrected an issue reported by mvstudio of where the expected text to be in front of the priced item would not be
+      displayed if the imgLoc variable in the includes/modules/pages/PRODUCT_TYPE/jscript_dynamic_price_updater.php file
+      was not set to "replace".  Essentially the result was that pspClass would be blank when sending to ajax.
+  - Added change detection and capture of the html element textarea and changed the text detection to an input event
+      instead of a keyup event.  This allows capture/detection of pasted content without firing off multiple events for
+      the same modification.  Additional testing may reveal the need to incorporate other event listeners. The process
+      would be similar as shown for the number case.
+  - Updated ajax.php file to prevent known spiders from performing ajax requests.  This is from the ZC 1.5.6 version of
+      the file.
+  - Moved the status notification from an alert to a console log when zcJS is not used and a 200 status result is not
+      received.
+*/
+
+
+$zc150 = (PROJECT_VERSION_MAJOR > 1 || (PROJECT_VERSION_MAJOR == 1 && substr(PROJECT_VERSION_MINOR, 0, 3) >= 5));
+if ($zc150) { // continue Zen Cart 1.5.0
+
+$sort_order = array(
+                array('configuration_group_id' => array('value' => $configuration_group_id,
+                                                   'type' => 'integer'),
+                      'configuration_key' => array('value' => 'DPU_ATTRIBUTES_MULTI_PRICE_TEXT',
+                                                   'type' => 'string'),
+                      'configuration_title' => array('value' => 'Show alternate text for partial selection',
+                                                   'type' => 'string'),
+                      'configuration_value' => array('value' => 'start_at_least',
+                                                   'type' => 'string'),
+                      'configuration_description' => array('value' => 'When selections are being made that affect the price of the product, what alternate text if any should be shown to the customer.  For example if when no selections have been made, the ZC starting at text may be displayed.  When one selection of many has been made, then the text may be changed to at least this amount indicating that there are selections to be made that could increase the price.  Then once all selections have been made as expected/required the text is or should change to something like Your Price:.<br /><br /><b>Default: start_at_least</b><br /><br />start_at_least: display applicable start at or at least text<br />start_at: display start_at text until all selections have been made<br />at_least: once a selection has been made that does not complete selection display the at_least text.',
+                                                   'type' => 'string'),
+                      'date_added' => array('value' => 'NOW()',
+                                                   'type' => 'noquotestring'),
+                      'use_function' => array('value' => 'NULL',
+                                                   'type' => 'noquotestring'),
+                      'set_function' => array('value' => 'zen_cfg_select_option(array(\'none\', \'start_at_least\', \'start_at\', \'at_least\'),',
+                                                   'type' => 'string'),
+                      ),
+                array('configuration_group_id' => array('value' => $configuration_group_id,
+                                                   'type' => 'integer'),
+                      'configuration_key' => array('value' => 'DPU_SHOW_OUT_OF_STOCK_IMAGE',
+                                                   'type' => 'string'),
+                      'configuration_title' => array('value' => 'Show or update the display of out-of-stock',
+                                                   'type' => 'string'),
+                      'configuration_value' => array('value' => 'quantity_replace',
+                                                   'type' => 'string'),
+                      'configuration_description' => array('value' => 'Allows display of the current stock status of a product while the customer remains on the product information page and offers control about the ajax update when the product is identified as out-of-stock.<br /><br /><b>default: quantity_replace</b><br /><br />quantity_replace: if incorporated, instead of showing the quantity of product, display DPU_OUT_OF_STOCK_IMAGE.<br />after: display DPU_OUT_OF_STOCK_IMAGE after the quantity display.<br />before: display DPU_OUT_OF_STOCK_IMAGE before the quantity display.<br />price_replace_only: update the price of the product to display DPU_OUT_OF_STOCK_IMAGE',
+                                                   'type' => 'string'),
+                      'date_added' => array('value' => 'NOW()',
+                                                   'type' => 'noquotestring'),
+                      'use_function' => array('value' => 'NULL',
+                                                   'type' => 'noquotestring'),
+                      'set_function' => array('value' => 'zen_cfg_select_option(array(\'quantity_replace\', \'after\', \'before\', \'price_replace_only\'),',
+                                                   'type' => 'string'),
+                      ),
+                array('configuration_group_id' => array('value' => $configuration_group_id,
+                                                   'type' => 'integer'),
+                      'configuration_key' => array('value' => 'DPU_PROCESS_ATTRIBUTES',
+                                                   'type' => 'string'),
+                      'configuration_title' => array('value' => 'Modify minimum attribute display price',
+                                                   'type' => 'string'),
+                      'configuration_value' => array('value' => 'all',
+                                                   'type' => 'string'),
+                      'configuration_description' => array('value' => 'On what should the minimum display price be based for product with attributes? <br /><br />Only product that are priced by attribute or for all product that have attributes?<br /><br /><b>Default: all</b>',
+                                                   'type' => 'string'),
+                      'date_added' => array('value' => 'NOW()',
+                                                   'type' => 'noquotestring'),
+                      'use_function' => array('value' => 'NULL',
+                                                   'type' => 'noquotestring'),
+                      'set_function' => array('value' => 'zen_cfg_select_option(array(\'all\', \'priced_by\'),',
+                                                   'type' => 'string'),
+                      ),
+                array('configuration_group_id' => array('value' => $configuration_group_id,
+                                                   'type' => 'integer'),
+                      'configuration_key' => array('value' => 'DPU_PRODUCTDETAILSLIST_PRODUCT_INFO_QUANTITY',
+                                                   'type' => 'string'),
+                      'configuration_title' => array('value' => 'Where to display the product_quantity',
+                                                   'type' => 'string'),
+                      'configuration_value' => array('value' => 'productDetailsList_product_info_quantity',
+                                                   'type' => 'string'),
+                      'configuration_description' => array('value' => 'This is the ID where your product quantity is displayed.<br /><br /><b>default => productDetailsList_product_info_quantity</b>',
+                                                   'type' => 'string'),
+                      'date_added' => array('value' => 'NOW()',
+                                                   'type' => 'noquotestring'),
+                      'use_function' => array('value' => 'NULL',
+                                                   'type' => 'noquotestring'),
+                      'set_function' => array('value' => 'NULL',
+                                                   'type' => 'noquotestring'),
+                      ),
+                );
+
+    $oldcount_sort_sql = "SELECT MAX(sort_order) as max_sort FROM `". TABLE_CONFIGURATION ."` WHERE configuration_group_id=" . (int)$configuration_group_id;
+    $oldcount_sort = $db->Execute($oldcount_sort_sql);
+
+    foreach ($sort_order as $config_key => $config_item) {
+        $sql = "INSERT INTO " . TABLE_CONFIGURATION . " (configuration_group_id, configuration_key, configuration_title, configuration_value, configuration_description, sort_order, date_added, use_function, set_function)
+          VALUES (:configuration_group_id:, :configuration_key:, :configuration_title:, :configuration_value:, :configuration_description:, :sort_order:, :date_added:, :use_function:, :set_function:)
+          ON DUPLICATE KEY UPDATE sort_order = :sort_order:";
+        $sql = $db->bindVars($sql, ':configuration_group_id:', $config_item['configuration_group_id']['value'], $config_item['configuration_group_id']['type']);
+        $sql = $db->bindVars($sql, ':configuration_key:', $config_item['configuration_key']['value'], $config_item['configuration_key']['type']);
+        $sql = $db->bindVars($sql, ':configuration_title:', $config_item['configuration_title']['value'], $config_item['configuration_title']['type']);
+        $sql = $db->bindVars($sql, ':configuration_value:', $config_item['configuration_value']['value'], $config_item['configuration_value']['type']);
+        $sql = $db->bindVars($sql, ':configuration_description:', $config_item['configuration_description']['value'], $config_item['configuration_description']['type']);
+        $sql = $db->bindVars($sql, ':sort_order:', (int)$oldcount_sort->fields['max_sort'] + ((int)$config_key + 1) * 10, 'integer');
+        $sql = $db->bindVars($sql, ':date_added:', $config_item['date_added']['value'], $config_item['date_added']['type']);
+        $sql = $db->bindVars($sql, ':use_function:', $config_item['use_function']['value'], $config_item['use_function']['type']);
+        $sql = $db->bindVars($sql, ':set_function:', $config_item['set_function']['value'], $config_item['set_function']['type']);
+        $db->Execute($sql);
+    }
+
+} // END OF VERSION 1.5.x INSTALL

--- a/Installation files/ajax.php
+++ b/Installation files/ajax.php
@@ -3,10 +3,10 @@
  * ajax front controller
  *
  * @package core
- * @copyright Copyright 2003-2016 Zen Cart Development Team
+ * @copyright Copyright 2003-2017 Zen Cart Development Team
  * @copyright Portions Copyright 2003 osCommerce
  * @license http://www.zen-cart.com/license/2_0.txt GNU Public License V2.0
- * @version $Id: Author: zcwilt  Thu Dec 31 19:12:00 2015 +0000 Modified in v1.5.5 $
+ * @version $Id:  Aug 2017 Modified in v1.5.6 $
  */
 // Abort if the request was not an AJAX call
 if (!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) != 'xmlhttprequest') {
@@ -14,6 +14,10 @@ if (!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || strtolower($_SERVER['HTTP_X_REQ
     exit();
 }
 require('includes/application_top.php');
+
+// deny ajax requests from spiders
+if (isset($spider_flag) && $spider_flag === true) ajaxAbort();
+
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET');
 header("Access-Control-Allow-Headers: X-Requested-With");

--- a/Installation files/includes/classes/dynamic_price_updater.php
+++ b/Installation files/includes/classes/dynamic_price_updater.php
@@ -142,7 +142,7 @@ class DPU extends base {
         break;
     }
     $this->responseText['priceTotal'] = $this->prefix;
-    $this->responseText['preDiscPriceTotal'] = $this->preDiscPrefix;
+    $this->responseText['preDiscPriceTotalText'] = $this->preDiscPrefix;
     
     $product_check = $db->Execute("SELECT products_tax_class_id FROM " . TABLE_PRODUCTS . " WHERE products_id = " . (int)$_POST['products_id'] . " LIMIT 1");
     if (DPU_SHOW_CURRENCY_SYMBOLS == 'false') {

--- a/Installation files/includes/classes/dynamic_price_updater.php
+++ b/Installation files/includes/classes/dynamic_price_updater.php
@@ -409,19 +409,20 @@ class DPU extends base {
           if (array_key_exists($options_id, $attributes) && zen_get_attributes_valid($_POST['products_id'], $options_id, $attributes[$options_id])) {
             // If the options_id selected is a valid attribute then add it to be part of the calculation
             $new_temp_attributes[$options_id] = $attributes[$options_id];
-          } elseif (array_key_exists($options_id, $attributes) && array_key_exists($options_id, $new_attributes) && !zen_get_attributes_valid($_POST['products_id'], $options_id, $attributes[$options_id])) {
+          } elseif (array_key_exists($options_id, $attributes) && !zen_get_attributes_valid($_POST['products_id'], $options_id, $attributes[$options_id])) {
             // If the options_id selected is not a valid attribute, then add a valid attribute determined above and mark it
             //   to be deleted from the shopping cart after the price has been determined.
             $this->new_temp_attributes[$options_id] = $attributes[$options_id];
             $new_temp_attributes[$options_id] = $new_attributes[$options_id];
             $this->unused++;
+          } /*elseif (array_key_exists($options_id, $attributes) && array_key_exists($options_id, $new_attributes) && !zen_get_attributes_valid($_POST['products_id'], $options_id, $attributes[$options_id])) {
           } elseif (array_key_exists($options_id, $new_attributes)) {
             // If the option_id has not been selected but is one that is to be populated, then add it to the cart and mark it
             //   to be deleted from the shopping cart after the price has been determined.
             $this->new_temp_attributes[$options_id] = $new_attributes[$options_id];
             $new_temp_attributes[$options_id] = $new_attributes[$options_id];
             $this->unused++;
-          }
+          }*/
             
           $products_options_names->MoveNext();
         }

--- a/Installation files/includes/classes/dynamic_price_updater.php
+++ b/Installation files/includes/classes/dynamic_price_updater.php
@@ -229,7 +229,7 @@ class DPU extends base {
       }
     }
 
-    if (is_array($attributes) && count($attributes)) {
+    if (!empty($attributes) || zen_has_product_attributes_values($_POST['products_id'])) {
       // If product is priced by attribute then determine which attributes had not been added, 
       //  add them to the attribute list such that product added to the cart is fully defined with the minimum value(s), though 
       //  at the moment seems that similar would be needed even for not priced by attribute possibly... Will see... Maybe someone will report if an issue.

--- a/Installation files/includes/classes/dynamic_price_updater.php
+++ b/Installation files/includes/classes/dynamic_price_updater.php
@@ -46,7 +46,7 @@ class DPU extends base {
    * @return DPU
    */
   public function __construct() {
-    global $db;
+//    global $db; // Variable unused.
     // grab the shopping cart class and instantiate it
     $this->shoppingCart = new shoppingCart();
   }
@@ -367,7 +367,7 @@ class DPU extends base {
     $qty = (float)$_POST['cart_quantity'];*/
     $out = array();
 //    $global_total;
-    $products = array();
+    //$products = array(); // Unnecessary define
     $products = $this->shoppingCart->get_products();
     for ($i=0, $n=count($products); $i<$n; $i++) 
     {

--- a/Installation files/includes/languages/english/extra_definitions/dynamic_price_updater.php
+++ b/Installation files/includes/languages/english/extra_definitions/dynamic_price_updater.php
@@ -22,5 +22,5 @@ define('DPU_SIDEBOX_FRAME', '<span class="DPUSideBoxName">%1$s</span>%3$s%2$s<br
  * %1$s - The attribute name
  * %2$s - The quantity display
  * %3$s - The individual price display
- * You can position these anywahere around the DPU_SIDEBOX_FRAME string or even remove them to prevent them from displaying
+ * You can position these anywhere around the DPU_SIDEBOX_FRAME string or even remove them to prevent them from displaying
  */

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -254,6 +254,7 @@ objXHR.prototype.getPrice = function () {
     switch (el.type) { <?php /* I'm not sure this even needed as a switch; testing needed*/ ?>
       case "select":
       case "select-one":
+      case "textarea":
       case "text":
       case "number":
       case "hidden":
@@ -532,8 +533,9 @@ function init() {
           xhr.getPrice();
         });
         break;
+      case "textarea":
       case "text":
-        theForm.elements[i].addEventListener("keyup", function () {
+        theForm.elements[i].addEventListener("input", function () {
           xhr.getPrice();
         });
         break;

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -113,7 +113,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
             _this.responseText = _this.XHR.responseText;
             _this.responseHandler(resFunc, _this);
           } else {
-            alert("Status returned - " + _this.XHR.statusText);
+            console.log("Status returned - " + _this.XHR.statusText);
           }
         }
       };

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -7,16 +7,12 @@
  * @licence This module is released under the GNU/GPL licence
  */
 
-if (DPU_STATUS == 'true')
-{
+if (defined('DPU_STATUS') && DPU_STATUS === 'true') {
   $load = true; // if any of the PHP conditions fail this will be set to false and DPU won't be fired up
   $pid = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0);
-  if (0==$pid)
-  {
+  if (0 == $pid) {
     $load = false;
-  }
-  elseif (zen_get_products_price_is_call($pid) || zen_get_products_price_is_free($pid) || STORE_STATUS > 0)
-  {
+  } elseif (zen_get_products_price_is_call($pid) || zen_get_products_price_is_free($pid) || STORE_STATUS > 0) {
     $load = false;
   }
   $pidp = zen_get_products_display_price($pid);
@@ -24,8 +20,7 @@ if (DPU_STATUS == 'true')
     $load = false;
   }
 
-  if ($load)
-  {
+  if ($load) {
 ?>
 <script type="text/javascript">
 // <![CDATA[
@@ -34,18 +29,18 @@ var theFormName = "<?php echo DPU_PRODUCT_FORM; ?>";
 var theForm = false;
 var theURL = "<?php echo DIR_WS_CATALOG; ?>ajax.php";
 // var theURL = "<?php echo DIR_WS_CATALOG; ?>dpu_ajax.php";
-var _secondPrice = <?php echo (DPU_SECOND_PRICE != '' ? '"' . DPU_SECOND_PRICE . '"' : 'false'); ?>;
+var _secondPrice = <?php echo (DPU_SECOND_PRICE !== '' ? '"' . DPU_SECOND_PRICE . '"' : 'false'); ?>;
 var objSP = false; // please don't adjust this
 var DPURequest = [];
 // Updater sidebox settings
-var objSB = false; // this holds the sidebox object // IE. Left sidebox false should become document.getElementById('leftBoxContainer');
+var objSB = false;<?php // this holds the sidebox object // IE. Left sidebox false should become document.getElementById('leftBoxContainer');
 // For right sidebox, this should equal document.getElementById('rightBoxContainer');
 // Perhaps this could be added as an additional admin configuration key.  The result should end up being that a new SideBox is added
 // before whatever is described in this "search".  So this may actually need to be a div within the left or right boxes instead of the
 // left or right side box.
 //   May also be that this it is entirely unnecessary to create a sidebox when one could already exist based on the file structure.
 
-<?php if (DPU_SHOW_LOADING_IMAGE == 'true') { // create the JS object for the loading image ?>
+if (DPU_SHOW_LOADING_IMAGE === 'true') { // create the JS object for the loading image ?>
 var imgLoc = "replace"; // Options are "replace" or , "" (empty)
 
 var origPrice;
@@ -60,8 +55,7 @@ loadImgSB.style.margin = "auto";
 // loadImg.style.display = 'none';
 <?php } ?>
 
-function objXHR()
-{ // scan the function clicked and act on it using the Ajax interthingy
+function objXHR() { // scan the function clicked and act on it using the Ajax interthingy
   var url; // URL to send HTTP DPURequests to
   var timer; // timer for timing things
   var XHR; // XMLHttpDPURequest object
@@ -103,17 +97,17 @@ objXHR.prototype.createXHR = function () { // this code has been modified from t
 };
 
 objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a DPURequest to the server in either GET or POST
-  strMode = (strMode.toLowerCase() == "post" ? "post" : "get");
+  strMode = (strMode.toLowerCase() === "post" ? "post" : "get");
   var _this = this; // scope resolution
 
-  if (((typeof zcJS == "undefined" || !zcJS) ? this.XHR : zcJS)) {
-    if (typeof zcJS == "undefined" || !zcJS) {
+  if (((typeof zcJS === "undefined" || !zcJS) ? this.XHR : zcJS)) {
+    if (typeof zcJS === "undefined" || !zcJS) {
       this.createXHR();
 
       this.XHR.onreadystatechange = function () {
-        if (_this.XHR.readyState == 4) {
+        if (_this.XHR.readyState === 4) {
         // only if "OK"
-          if (_this.XHR.status == 200) {
+          if (_this.XHR.status === 200) {
             _this.responseXML = _this.XHR.responseXML;
             _this.responseText = _this.XHR.responseText;
             _this.responseHandler(resFunc, _this);
@@ -122,52 +116,55 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
           }
         }
       };
-      this.XHR.open(strMode.toLowerCase(), this.url+"?act=DPU_Ajax&method=dpu_update"+(strMode.toLowerCase() == "get" ? "&" + this.compileRequest() : "")+<?php
+
+      this.XHR.open(strMode.toLowerCase(), "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
    
-   $all_get_params = zen_get_all_get_params();
-   
-   echo (!empty($all_get_params)) ? '"&' . preg_replace("/&$/","",$all_get_params) . '"' : '""'; 
-                    
-                    ?>, true);
-      if (strMode.toLowerCase() == "post") {
+/*                        this.XHR.open(strMode.toLowerCase(), this.url+"?act=DPU_Ajax&method=dpu_update"+(strMode.toLowerCase() == "get" ? "&" + this.compileRequest() : ""), true);*/
+      if (strMode.toLowerCase() === "post") {
         this.XHR.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
         this.XHR.setRequestHeader("X-Requested-With", "XMLHttpRequest");
       }
-      this.XHR.send(combinedData["XML"]);
+      this.XHR.send(combinedData.XML);
     } else {
-      var option = { url : theURL+"?act=DPU_Ajax&method=dpu_update<?php
-   
-   echo (!empty($all_get_params)) ? '&' . preg_replace("/&$/","", $all_get_params) : ''; 
-                    
-                    ?>",
-                    data : combinedData["JSON"],
+      var option = {
+          url: "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>",
+                    data: combinedData.JSON,
                      timeout : 30000
                    };
       zcJS.ajax(option).done(
           function (response,textStatus,jqXHR) {
             _this.responseJSON = jqXHR.responseJSON;
             _this.responseText = jqXHR.responseText;
+            if (!_this.responseJSON && _this.responseText) {
+                try {
+                    _this.responseJSON = JSON.parse(_this.responseText);
+                } catch (e) {
+                     console.log(e.stack);
+                }
+            }
             _this.responseHandler(resFunc, _this);
           }
         ).fail( function(jqXHR,textStatus,errorThrown) {
-           <?php if (DPU_SHOW_LOADING_IMAGE == 'true') { ?>
+           <?php if (DPU_SHOW_LOADING_IMAGE === 'true') { ?>
             var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
             var test = thePrice.getElementsByTagName("span");
             var psp = false;
+            var a;
+            var b = test.length;
 
-            for (var a=0,b=test.length; a<b; a++) {
-              if (test[a].className == "productSpecialPrice" || test[a].className == "productSalePrice" || test[a].className == "productSpecialPriceSale") {
+            for (a = 0; a < b; a += 1) {
+              if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
                 psp = test[a];
               }
             }
 
-            if (typeof(loadImg) !== "undefined" && loadImg.parentNode != null && loadImg.parentNode.id == thePrice.id && imgLoc != "replace") {
+            if (typeof(loadImg) !== "undefined" && loadImg.parentNode !== null && loadImg.parentNode.id === thePrice.id && imgLoc !== "replace") {
               if (psp) {
                 psp.removeChild(loadImg);
               } else {
                 thePrice.removeChild(loadImg);
               }
-            } else if (typeof(loadImg) !== "undefined" && imgLoc == "replace") {
+            } else if (typeof(loadImg) !== "undefined" && imgLoc === "replace") {
               _this.updateInnerHTML(origPrice, psp, thePrice);
             }
             if (_secondPrice !== false) {
@@ -187,8 +184,9 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
 objXHR.prototype.compileRequest = function () {
   // parse the DPURequest array into a URL encoded string
   var ret = ""; // return DPURequest string
+  var e;
 
-  for (var e in DPURequest) {
+  for (e in DPURequest) {
     ret += e + "=" + DPURequest[e] + "&";
   }
 
@@ -202,15 +200,17 @@ objXHR.prototype.responseHandler = function (theFunction, results) { // redirect
 
 objXHR.prototype.getPrice = function () {
     var pspClass = false;
-    <?php if (DPU_SHOW_LOADING_IMAGE == 'true') { ?>
+    <?php if (DPU_SHOW_LOADING_IMAGE === 'true') { ?>
 
     var psp = false;
-    if (imgLoc == "replace") {
+    if (imgLoc === "replace") {
       var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
       var test = thePrice.getElementsByTagName("span");
+      var a;
+      var b = test.length;
 
-      for (var a=0,b=test.length; a<b; a++) {
-        if (test[a].className == "productSpecialPrice" || test[a].className == "productSalePrice" || test[a].className == "productSpecialPriceSale") {
+      for (a = 0; a < b; a += 1) {
+        if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
           psp = test[a];
         }
       }
@@ -218,7 +218,7 @@ objXHR.prototype.getPrice = function () {
         psp = thePrice;
       }
     }
-    if (psp && imgLoc == "replace") {
+    if (psp && imgLoc === "replace") {
       if (thePrice) {
         loadImg.style.display = "inline"; //'block';
         pspClass = psp.className;
@@ -245,9 +245,11 @@ objXHR.prototype.getPrice = function () {
   var temp = "";
   var jsonData = {};
   var combinedData = {};
+  var el;
+  var i;
 
-  for (var i=0; i<n; i++) {
-    var el = theForm.elements[i];
+  for (i = 0; i < n; i += 1) {
+    el = theForm.elements[i];
     switch (el.type) { <?php /* I'm not sure this even needed as a switch; testing needed*/ ?>
       case "select":
       case "select-one":
@@ -261,7 +263,7 @@ objXHR.prototype.getPrice = function () {
         break;
       case "checkbox":
       case "radio":
-        if (true == el.checked) {
+        if (true === el.checked) {
           temp += el.name+"="+encodeURIComponent(el.value)+"&";
           if (!(el.name in jsonData)) { // Ensure not to replace an existing value. I.e. drop a duplicate value.
             jsonData[el.name] = el.value;
@@ -270,24 +272,24 @@ objXHR.prototype.getPrice = function () {
         break;
     }
   }
-  if (!('products_id' in jsonData)) {
+  if (!("products_id" in jsonData)) {
     temp += "products_id=<?php echo (int)$pid; ?>&";
-    jsonData['products_id'] = <?php echo (int)$pid; ?>;
+    jsonData.products_id = <?php echo (int)$pid; ?>;
   }
   if (pspClass) {
     temp += "pspClass="+encodeURIComponent(pspClass)+"&";
-    jsonData["pspClass"] = pspClass;
+    jsonData.pspClass = pspClass;
   }
 
   temp += "stat=main&";
-  jsonData["stat"] = "main";
+  jsonData.stat = "main";
 
   temp += "outputType=XML&";
-  jsonData["outputType"] = "JSON";
+  jsonData.outputType = "JSON";
   temp = temp.substr(0, temp.length - 1);
 
-  combinedData["XML"] = temp;
-  combinedData["JSON"] = jsonData;
+  combinedData.XML = temp;
+  combinedData.JSON = jsonData;
 
   this.getData("post", "handlePrice", combinedData);
 
@@ -299,7 +301,7 @@ objXHR.prototype.updateInnerHTML = function (storeVal, psp, obj, replace) {
   if (typeof(replace) === "undefined") {
     replace = true;
   }
-  if (storeVal != "") {
+  if (storeVal !== "") {
           if (psp) {
             if (replace) {
               psp.innerHTML = storeVal;
@@ -322,25 +324,29 @@ objXHR.prototype.updateInnerHTML = function (storeVal, psp, obj, replace) {
 
 objXHR.prototype.handlePrice = function (results) {
   var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
-  if (typeof(loadImg) !== "undefined" && loadImg.parentNode != null && loadImg.parentNode.id == thePrice.id && imgLoc != "replace") {
+  if (typeof(loadImg) !== "undefined" && loadImg.parentNode !== null && loadImg.parentNode.id === thePrice.id && imgLoc !== "replace") {
     thePrice.removeChild(loadImg);
   }
 
   // use the spans to see if there is a discount occuring up in this here house
   var test = thePrice.getElementsByTagName("span");
   var psp = false;
+  var a;
+  var b = test.length;
 
-  for (var a=0,b=test.length; a<b; a++) {
-    if (test[a].className == "productSpecialPrice" || test[a].className == "productSalePrice" || test[a].className == "productSpecialPriceSale") {
+  for (a = 0; a < b; a += 1) {
+    if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
       psp = test[a];
     }
   }
 
 //  var type = this.responseXML.getElementsByTagName("responseType")[0].childNodes[0].nodeValue;
+  var type;
+  var updateSidebox;
   if (results.responseXML) {
-    var type = results.responseXML.getElementsByTagName("responseType")[0].childNodes[0].nodeValue;
+    type = results.responseXML.getElementsByTagName("responseType")[0].childNodes[0].nodeValue;
   } else if (results.responseJSON) {
-    var type = results.responseJSON.responseType;
+    type = results.responseJSON.responseType;
   }
 
     if (document.getElementById("dynamicpriceupdatersidebox")) {
@@ -351,28 +357,31 @@ objXHR.prototype.handlePrice = function (results) {
     } else {
         updateSidebox = false;
     }
-  if (type == "error") {
+  if (type === "error") {
     this.showErrors();
   } else {
 //    var temp = this.responseXML.getElementsByTagName("responseText");
+    var temp;
     if (results.responseXML) {
-      var temp = results.responseXML.getElementsByTagName("responseText");
+      temp = results.responseXML.getElementsByTagName("responseText");
     } else if (results.responseJSON) {
-      var temp = results.responseJSON.data;
+      temp = results.responseJSON.data;
     }
 
 /*    for(var i=0, n=temp.length; i<n; i++) {
       var type = temp[i].getAttribute("type");*/
-    for(var i in temp) {
+    var storeVal;
+    var i;
+    for(i in temp) {
       if (results.responseXML) {
         if (!(temp.hasOwnProperty(i))) {
           continue;
         }
-        var type = temp[i].getAttribute("type");
-        var storeVal = temp[i].childNodes[0].nodeValue;
+        type = temp[i].getAttribute("type");
+        storeVal = temp[i].childNodes[0].nodeValue;
       } else if (results.responseJSON) {
-        var type = i;
-        var storeVal = temp[i];
+        type = i;
+        storeVal = temp[i];
       }
 
       switch (type) {<?php // the 'type' attribute defines what type of information is being provided ?>
@@ -431,7 +440,7 @@ objXHR.prototype.updSP = function () {
     var centre = document.getElementById("productGeneral");
     var temp = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
     var itemp = document.getElementById(_secondPrice);
-    var flag = false;
+    flag = false;
 
     if (objSP === false) { // create the second price object
       if (!temp || !itemp) {
@@ -450,13 +459,11 @@ objXHR.prototype.updSP = function () {
 <?php
 $show_dynamic_price_updater_sidebox = true;
 
-  if ($show_dynamic_price_updater_sidebox == true)
+  if ($show_dynamic_price_updater_sidebox === true)
   {
 ?>
-    objXHR.prototype.createSB = function ()
-    { // create the sidebox for the attributes info display
-      if (!(document.getElementById("dynamicpriceupdatersidebox")) && objSB)
-      {
+    objXHR.prototype.createSB = function () { // create the sidebox for the attributes info display
+      if (!(document.getElementById("dynamicpriceupdatersidebox")) && objSB) {
         var tempC = document.createElement("div");
         tempC.id = "dynamicpriceupdatersideboxContent";
         tempC.className = "sideBoxContent";
@@ -473,19 +480,21 @@ objXHR.prototype.showErrors = function () {
 //  var errorText = this.responseXML.getElementsByTagName("responseText");
   var alertText = "";
   var errVal;
+  var errorText;
+  var i;
 
-  if (typeof zcJS == "undefined" || !zcJS) {
-    var errorText = this.responseXML.getElementsByTagName("responseText");
+  if (typeof zcJS === "undefined" || !zcJS) {
+    errorText = this.responseXML.getElementsByTagName("responseText");
   } else {
-    var errorText = this.responseJSON.responseText;
+    errorText = this.responseJSON.responseText;
   }
   //var n=errorText.length;
 
-  for (var i in errorText/*var i=0; i<n; i++*/) {
+  for (i in errorText/*var i=0; i<n; i++*/) {
     if (!(errorText.hasOwnProperty(i))) {
       continue;
     }
-    if (typeof zcJS == "undefined" || !zcJS) {
+    if (typeof zcJS === "undefined" || !zcJS) {
       errVal = errorText[i].childNodes[0].nodeValue;
     } else {
       errVal = i;
@@ -499,31 +508,44 @@ var xhr = new objXHR;
 
 function init() {
   var n=document.forms.length;
-  for (var i=0; i<n; i++) {
-    if (document.forms[i].name == theFormName) {
+  var i;
+  for (i = 0; i < n; i += 1) {
+    if (document.forms[i].name === theFormName) {
       theForm = document.forms[i];
-      continue;
+      //continue; // Unnecessary though had originally thought of building more into this area.
     }
   }
 
-  var n=theForm.elements.length;
-  for (var i=0; i<n; i++) {
+  n=theForm.elements.length;
+  for (i = 0; i < n; i += 1) {
     switch (theForm.elements[i].type) {
       case "select":
       case "select-one":
-        theForm.elements[i].addEventListener("change", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("change", function () {
+          xhr.getPrice();
+        });
         break;
       case "text":
-        theForm.elements[i].addEventListener("keyup", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("keyup", function () {
+          xhr.getPrice();
+        });
         break;
       case "checkbox":
       case "radio":
-        theForm.elements[i].addEventListener("click", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("click", function () {
+          xhr.getPrice();
+        });
         break;
       case "number":
-        theForm.elements[i].addEventListener("change", function () { xhr.getPrice(); });
-        theForm.elements[i].addEventListener("keyup", function () { xhr.getPrice(); });
-        theForm.elements[i].addEventListener("input", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("change", function () {
+          xhr.getPrice();
+        });
+        theForm.elements[i].addEventListener("keyup", function () {
+          xhr.getPrice();
+        });
+        theForm.elements[i].addEventListener("input", function () {
+          xhr.getPrice();
+        });
         break;
     }
   }
@@ -531,7 +553,7 @@ function init() {
 <?php
   $show_dynamic_price_updater_sidebox = true;
 
-    if ($show_dynamic_price_updater_sidebox == true)
+    if ($show_dynamic_price_updater_sidebox === true)
     {
 ?>
     xhr.createSB();
@@ -539,7 +561,7 @@ function init() {
     }
 ?>
   xhr.getPrice();
-};
+}
 
 <?php
 // the following statements should allow multiple onload handlers to be applied

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -342,8 +342,12 @@ objXHR.prototype.handlePrice = function (results) {
   var psp = false;
   var a;
   var b = test.length;
+  var pdpt = false;
 
   for (a = 0; a < b; a += 1) {
+    if (test[a].className === "normalprice") {
+      pdpt = test[a];
+    }
     if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
       psp = test[a];
     }
@@ -394,6 +398,20 @@ objXHR.prototype.handlePrice = function (results) {
       }
 
       switch (type) {<?php // the 'type' attribute defines what type of information is being provided ?>
+
+        case "preDiscPriceTotal":
+          if (pdpt) {
+            this.updateInnerHTML(storeVal, pdpt, thePrice, true);
+          }
+          break;
+        case "preDiscPriceTotalText":
+          if (pdpt) {
+//          $(thePrice).contents().first()[0].textContent = storeVal;
+            if (thePrice.firstChild.nodeType === 3) {
+              thePrice.firstChild.nodeValue = storeVal;
+            }
+          }
+          break;
         case "priceTotal":
           /*if (psp) {
             psp.innerHTML = temp[i].childNodes[0].nodeValue;

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -21,6 +21,7 @@ if (defined('DPU_STATUS') && DPU_STATUS === 'true') {
   }
 
   if ($load) {
+    if (!defined('DPU_PRODUCTDETAILSLIST_PRODUCT_INFO_QUANTITY')) define('DPU_PRODUCTDETAILSLIST_PRODUCT_INFO_QUANTITY', 'productDetailsList_product_info_quantity');
 ?>
 <script type="text/javascript">
 // <![CDATA[
@@ -421,6 +422,12 @@ objXHR.prototype.handlePrice = function (results) {
           if (updateSidebox) {
 //            sbContent += temp[i].childNodes[0].nodeValue;
             sbContent += storeVal;
+          }
+          break;
+        case "stock_quantity":
+          var theStockQuantity = document.getElementById("<?php echo DPU_PRODUCTDETAILSLIST_PRODUCT_INFO_QUANTITY; ?>");
+          if (theStockQuantity) {
+            this.updateInnerHTML(storeVal, false, theStockQuantity, true);
           }
           break;
       }

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -118,7 +118,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
         }
       };
 
-      this.XHR.open(strMode.toLowerCase(), "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
+      this.XHR.open(strMode.toLowerCase(), "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params(array('action','pid')) . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
    
 /*                        this.XHR.open(strMode.toLowerCase(), this.url+"?act=DPU_Ajax&method=dpu_update"+(strMode.toLowerCase() == "get" ? "&" + this.compileRequest() : ""), true);*/
       if (strMode.toLowerCase() === "post") {
@@ -128,7 +128,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
       this.XHR.send(combinedData.XML);
     } else {
       var option = {
-          url: "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>",
+          url: "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params(array('action','pid')) . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>",
                     data: combinedData.JSON,
                      timeout : 30000
                    };

--- a/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_info/jscript_dynamic_price_updater.php
@@ -204,9 +204,12 @@ objXHR.prototype.getPrice = function () {
     <?php if (DPU_SHOW_LOADING_IMAGE === 'true') { ?>
 
     var psp = false;
-    if (imgLoc === "replace") {
+//    if (imgLoc === "replace") {
       var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
-      var test = thePrice.getElementsByTagName("span");
+      var test = false;
+      if (thePrice) {
+        test = thePrice.getElementsByTagName("span");
+      }
       var a;
       var b = test.length;
 
@@ -218,11 +221,15 @@ objXHR.prototype.getPrice = function () {
       if (!psp) {
         psp = thePrice;
       }
-    }
+      if (psp) {
+        pspClass = psp.className;
+        origPrice = psp.innerHTML;
+      }
+//  }
     if (psp && imgLoc === "replace") {
       if (thePrice) {
         loadImg.style.display = "inline"; //'block';
-        pspClass = psp.className;
+//        pspClass = psp.className;
         var pspStyle = psp.currentStyle || window.getComputedStyle(psp);
         loadImg.style.height = pspStyle.lineHeight; // Maintains the height so that there is not a vertical shift of the content.
         origPrice = psp.innerHTML;

--- a/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
@@ -254,6 +254,7 @@ objXHR.prototype.getPrice = function () {
     switch (el.type) { <?php /* I'm not sure this even needed as a switch; testing needed*/ ?>
       case "select":
       case "select-one":
+      case "textarea":
       case "text":
       case "number":
       case "hidden":
@@ -532,8 +533,9 @@ function init() {
           xhr.getPrice();
         });
         break;
+      case "textarea":
       case "text":
-        theForm.elements[i].addEventListener("keyup", function () {
+        theForm.elements[i].addEventListener("input", function () {
           xhr.getPrice();
         });
         break;

--- a/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
@@ -113,7 +113,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
             _this.responseText = _this.XHR.responseText;
             _this.responseHandler(resFunc, _this);
           } else {
-            alert("Status returned - " + _this.XHR.statusText);
+            console.log("Status returned - " + _this.XHR.statusText);
           }
         }
       };

--- a/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
@@ -342,8 +342,12 @@ objXHR.prototype.handlePrice = function (results) {
   var psp = false;
   var a;
   var b = test.length;
+  var pdpt = false;
 
   for (a = 0; a < b; a += 1) {
+    if (test[a].className === "normalprice") {
+      pdpt = test[a];
+    }
     if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
       psp = test[a];
     }
@@ -394,6 +398,20 @@ objXHR.prototype.handlePrice = function (results) {
       }
 
       switch (type) {<?php // the 'type' attribute defines what type of information is being provided ?>
+
+        case "preDiscPriceTotal":
+          if (pdpt) {
+            this.updateInnerHTML(storeVal, pdpt, thePrice, true);
+          }
+          break;
+        case "preDiscPriceTotalText":
+          if (pdpt) {
+//          $(thePrice).contents().first()[0].textContent = storeVal;
+            if (thePrice.firstChild.nodeType === 3) {
+              thePrice.firstChild.nodeValue = storeVal;
+            }
+          }
+          break;
         case "priceTotal":
           /*if (psp) {
             psp.innerHTML = temp[i].childNodes[0].nodeValue;

--- a/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
@@ -21,6 +21,7 @@ if (defined('DPU_STATUS') && DPU_STATUS === 'true') {
   }
 
   if ($load) {
+    if (!defined('DPU_PRODUCTDETAILSLIST_PRODUCT_INFO_QUANTITY')) define('DPU_PRODUCTDETAILSLIST_PRODUCT_INFO_QUANTITY', 'productDetailsList_product_info_quantity');
 ?>
 <script type="text/javascript">
 // <![CDATA[
@@ -421,6 +422,12 @@ objXHR.prototype.handlePrice = function (results) {
           if (updateSidebox) {
 //            sbContent += temp[i].childNodes[0].nodeValue;
             sbContent += storeVal;
+          }
+          break;
+        case "stock_quantity":
+          var theStockQuantity = document.getElementById("<?php echo DPU_PRODUCTDETAILSLIST_PRODUCT_INFO_QUANTITY; ?>");
+          if (theStockQuantity) {
+            this.updateInnerHTML(storeVal, false, theStockQuantity, true);
           }
           break;
       }

--- a/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
@@ -7,16 +7,12 @@
  * @licence This module is released under the GNU/GPL licence
  */
 
-if (DPU_STATUS == 'true')
-{
+if (defined('DPU_STATUS') && DPU_STATUS === 'true') {
   $load = true; // if any of the PHP conditions fail this will be set to false and DPU won't be fired up
   $pid = (!empty($_GET['products_id']) ? (int)$_GET['products_id'] : 0);
-  if (0==$pid)
-  {
+  if (0 == $pid) {
     $load = false;
-  }
-  elseif (zen_get_products_price_is_call($pid) || zen_get_products_price_is_free($pid) || STORE_STATUS > 0)
-  {
+  } elseif (zen_get_products_price_is_call($pid) || zen_get_products_price_is_free($pid) || STORE_STATUS > 0) {
     $load = false;
   }
   $pidp = zen_get_products_display_price($pid);
@@ -24,8 +20,7 @@ if (DPU_STATUS == 'true')
     $load = false;
   }
 
-  if ($load)
-  {
+  if ($load) {
 ?>
 <script type="text/javascript">
 // <![CDATA[
@@ -34,18 +29,18 @@ var theFormName = "<?php echo DPU_PRODUCT_FORM; ?>";
 var theForm = false;
 var theURL = "<?php echo DIR_WS_CATALOG; ?>ajax.php";
 // var theURL = "<?php echo DIR_WS_CATALOG; ?>dpu_ajax.php";
-var _secondPrice = <?php echo (DPU_SECOND_PRICE != '' ? '"' . DPU_SECOND_PRICE . '"' : 'false'); ?>;
+var _secondPrice = <?php echo (DPU_SECOND_PRICE !== '' ? '"' . DPU_SECOND_PRICE . '"' : 'false'); ?>;
 var objSP = false; // please don't adjust this
 var DPURequest = [];
 // Updater sidebox settings
-var objSB = false; // this holds the sidebox object // IE. Left sidebox false should become document.getElementById('leftBoxContainer');
+var objSB = false;<?php // this holds the sidebox object // IE. Left sidebox false should become document.getElementById('leftBoxContainer');
 // For right sidebox, this should equal document.getElementById('rightBoxContainer');
 // Perhaps this could be added as an additional admin configuration key.  The result should end up being that a new SideBox is added
 // before whatever is described in this "search".  So this may actually need to be a div within the left or right boxes instead of the
 // left or right side box.
 //   May also be that this it is entirely unnecessary to create a sidebox when one could already exist based on the file structure.
 
-<?php if (DPU_SHOW_LOADING_IMAGE == 'true') { // create the JS object for the loading image ?>
+if (DPU_SHOW_LOADING_IMAGE === 'true') { // create the JS object for the loading image ?>
 var imgLoc = "replace"; // Options are "replace" or , "" (empty)
 
 var origPrice;
@@ -60,8 +55,7 @@ loadImgSB.style.margin = "auto";
 // loadImg.style.display = 'none';
 <?php } ?>
 
-function objXHR()
-{ // scan the function clicked and act on it using the Ajax interthingy
+function objXHR() { // scan the function clicked and act on it using the Ajax interthingy
   var url; // URL to send HTTP DPURequests to
   var timer; // timer for timing things
   var XHR; // XMLHttpDPURequest object
@@ -103,17 +97,17 @@ objXHR.prototype.createXHR = function () { // this code has been modified from t
 };
 
 objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a DPURequest to the server in either GET or POST
-  strMode = (strMode.toLowerCase() == "post" ? "post" : "get");
+  strMode = (strMode.toLowerCase() === "post" ? "post" : "get");
   var _this = this; // scope resolution
 
-  if (((typeof zcJS == "undefined" || !zcJS) ? this.XHR : zcJS)) {
-    if (typeof zcJS == "undefined" || !zcJS) {
+  if (((typeof zcJS === "undefined" || !zcJS) ? this.XHR : zcJS)) {
+    if (typeof zcJS === "undefined" || !zcJS) {
       this.createXHR();
 
       this.XHR.onreadystatechange = function () {
-        if (_this.XHR.readyState == 4) {
+        if (_this.XHR.readyState === 4) {
         // only if "OK"
-          if (_this.XHR.status == 200) {
+          if (_this.XHR.status === 200) {
             _this.responseXML = _this.XHR.responseXML;
             _this.responseText = _this.XHR.responseText;
             _this.responseHandler(resFunc, _this);
@@ -122,42 +116,55 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
           }
         }
       };
-      this.XHR.open(strMode.toLowerCase(), this.url+"?act=DPU_Ajax&method=dpu_update"+(strMode.toLowerCase() == "get" ? "&" + this.compileRequest() : ""), true);
-      if (strMode.toLowerCase() == "post") {
+
+      this.XHR.open(strMode.toLowerCase(), "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
+   
+/*                        this.XHR.open(strMode.toLowerCase(), this.url+"?act=DPU_Ajax&method=dpu_update"+(strMode.toLowerCase() == "get" ? "&" + this.compileRequest() : ""), true);*/
+      if (strMode.toLowerCase() === "post") {
         this.XHR.setRequestHeader("Content-Type","application/x-www-form-urlencoded");
         this.XHR.setRequestHeader("X-Requested-With", "XMLHttpRequest");
       }
-      this.XHR.send(combinedData["XML"]);
+      this.XHR.send(combinedData.XML);
     } else {
-      var option = { url : theURL+"?act=DPU_Ajax&method=dpu_update",
-                    data : combinedData["JSON"],
+      var option = {
+          url: "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>",
+                    data: combinedData.JSON,
                      timeout : 30000
                    };
       zcJS.ajax(option).done(
           function (response,textStatus,jqXHR) {
             _this.responseJSON = jqXHR.responseJSON;
             _this.responseText = jqXHR.responseText;
+            if (!_this.responseJSON && _this.responseText) {
+                try {
+                    _this.responseJSON = JSON.parse(_this.responseText);
+                } catch (e) {
+                     console.log(e.stack);
+                }
+            }
             _this.responseHandler(resFunc, _this);
           }
         ).fail( function(jqXHR,textStatus,errorThrown) {
-           <?php if (DPU_SHOW_LOADING_IMAGE == 'true') { ?>
+           <?php if (DPU_SHOW_LOADING_IMAGE === 'true') { ?>
             var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
             var test = thePrice.getElementsByTagName("span");
             var psp = false;
+            var a;
+            var b = test.length;
 
-            for (var a=0,b=test.length; a<b; a++) {
-              if (test[a].className == "productSpecialPrice" || test[a].className == "productSalePrice" || test[a].className == "productSpecialPriceSale") {
+            for (a = 0; a < b; a += 1) {
+              if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
                 psp = test[a];
               }
             }
 
-            if (typeof(loadImg) !== "undefined" && loadImg.parentNode != null && loadImg.parentNode.id == thePrice.id && imgLoc != "replace") {
+            if (typeof(loadImg) !== "undefined" && loadImg.parentNode !== null && loadImg.parentNode.id === thePrice.id && imgLoc !== "replace") {
               if (psp) {
                 psp.removeChild(loadImg);
               } else {
                 thePrice.removeChild(loadImg);
               }
-            } else if (typeof(loadImg) !== "undefined" && imgLoc == "replace") {
+            } else if (typeof(loadImg) !== "undefined" && imgLoc === "replace") {
               _this.updateInnerHTML(origPrice, psp, thePrice);
             }
             if (_secondPrice !== false) {
@@ -177,8 +184,9 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
 objXHR.prototype.compileRequest = function () {
   // parse the DPURequest array into a URL encoded string
   var ret = ""; // return DPURequest string
+  var e;
 
-  for (var e in DPURequest) {
+  for (e in DPURequest) {
     ret += e + "=" + DPURequest[e] + "&";
   }
 
@@ -192,15 +200,17 @@ objXHR.prototype.responseHandler = function (theFunction, results) { // redirect
 
 objXHR.prototype.getPrice = function () {
     var pspClass = false;
-    <?php if (DPU_SHOW_LOADING_IMAGE == 'true') { ?>
+    <?php if (DPU_SHOW_LOADING_IMAGE === 'true') { ?>
 
     var psp = false;
-    if (imgLoc == "replace") {
+    if (imgLoc === "replace") {
       var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
       var test = thePrice.getElementsByTagName("span");
+      var a;
+      var b = test.length;
 
-      for (var a=0,b=test.length; a<b; a++) {
-        if (test[a].className == "productSpecialPrice" || test[a].className == "productSalePrice" || test[a].className == "productSpecialPriceSale") {
+      for (a = 0; a < b; a += 1) {
+        if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
           psp = test[a];
         }
       }
@@ -208,7 +218,7 @@ objXHR.prototype.getPrice = function () {
         psp = thePrice;
       }
     }
-    if (psp && imgLoc == "replace") {
+    if (psp && imgLoc === "replace") {
       if (thePrice) {
         loadImg.style.display = "inline"; //'block';
         pspClass = psp.className;
@@ -235,9 +245,11 @@ objXHR.prototype.getPrice = function () {
   var temp = "";
   var jsonData = {};
   var combinedData = {};
+  var el;
+  var i;
 
-  for (var i=0; i<n; i++) {
-    var el = theForm.elements[i];
+  for (i = 0; i < n; i += 1) {
+    el = theForm.elements[i];
     switch (el.type) { <?php /* I'm not sure this even needed as a switch; testing needed*/ ?>
       case "select":
       case "select-one":
@@ -251,7 +263,7 @@ objXHR.prototype.getPrice = function () {
         break;
       case "checkbox":
       case "radio":
-        if (true == el.checked) {
+        if (true === el.checked) {
           temp += el.name+"="+encodeURIComponent(el.value)+"&";
           if (!(el.name in jsonData)) { // Ensure not to replace an existing value. I.e. drop a duplicate value.
             jsonData[el.name] = el.value;
@@ -260,24 +272,24 @@ objXHR.prototype.getPrice = function () {
         break;
     }
   }
-  if (!('products_id' in jsonData)) {
+  if (!("products_id" in jsonData)) {
     temp += "products_id=<?php echo (int)$pid; ?>&";
-    jsonData['products_id'] = <?php echo (int)$pid; ?>;
+    jsonData.products_id = <?php echo (int)$pid; ?>;
   }
   if (pspClass) {
     temp += "pspClass="+encodeURIComponent(pspClass)+"&";
-    jsonData["pspClass"] = pspClass;
+    jsonData.pspClass = pspClass;
   }
 
   temp += "stat=main&";
-  jsonData["stat"] = "main";
+  jsonData.stat = "main";
 
   temp += "outputType=XML&";
-  jsonData["outputType"] = "JSON";
+  jsonData.outputType = "JSON";
   temp = temp.substr(0, temp.length - 1);
 
-  combinedData["XML"] = temp;
-  combinedData["JSON"] = jsonData;
+  combinedData.XML = temp;
+  combinedData.JSON = jsonData;
 
   this.getData("post", "handlePrice", combinedData);
 
@@ -289,7 +301,7 @@ objXHR.prototype.updateInnerHTML = function (storeVal, psp, obj, replace) {
   if (typeof(replace) === "undefined") {
     replace = true;
   }
-  if (storeVal != "") {
+  if (storeVal !== "") {
           if (psp) {
             if (replace) {
               psp.innerHTML = storeVal;
@@ -312,25 +324,29 @@ objXHR.prototype.updateInnerHTML = function (storeVal, psp, obj, replace) {
 
 objXHR.prototype.handlePrice = function (results) {
   var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
-  if (typeof(loadImg) !== "undefined" && loadImg.parentNode != null && loadImg.parentNode.id == thePrice.id && imgLoc != "replace") {
+  if (typeof(loadImg) !== "undefined" && loadImg.parentNode !== null && loadImg.parentNode.id === thePrice.id && imgLoc !== "replace") {
     thePrice.removeChild(loadImg);
   }
 
   // use the spans to see if there is a discount occuring up in this here house
   var test = thePrice.getElementsByTagName("span");
   var psp = false;
+  var a;
+  var b = test.length;
 
-  for (var a=0,b=test.length; a<b; a++) {
-    if (test[a].className == "productSpecialPrice" || test[a].className == "productSalePrice" || test[a].className == "productSpecialPriceSale") {
+  for (a = 0; a < b; a += 1) {
+    if (test[a].className === "productSpecialPrice" || test[a].className === "productSalePrice" || test[a].className === "productSpecialPriceSale") {
       psp = test[a];
     }
   }
 
 //  var type = this.responseXML.getElementsByTagName("responseType")[0].childNodes[0].nodeValue;
+  var type;
+  var updateSidebox;
   if (results.responseXML) {
-    var type = results.responseXML.getElementsByTagName("responseType")[0].childNodes[0].nodeValue;
+    type = results.responseXML.getElementsByTagName("responseType")[0].childNodes[0].nodeValue;
   } else if (results.responseJSON) {
-    var type = results.responseJSON.responseType;
+    type = results.responseJSON.responseType;
   }
 
     if (document.getElementById("dynamicpriceupdatersidebox")) {
@@ -341,28 +357,31 @@ objXHR.prototype.handlePrice = function (results) {
     } else {
         updateSidebox = false;
     }
-  if (type == "error") {
+  if (type === "error") {
     this.showErrors();
   } else {
 //    var temp = this.responseXML.getElementsByTagName("responseText");
+    var temp;
     if (results.responseXML) {
-      var temp = results.responseXML.getElementsByTagName("responseText");
+      temp = results.responseXML.getElementsByTagName("responseText");
     } else if (results.responseJSON) {
-      var temp = results.responseJSON.data;
+      temp = results.responseJSON.data;
     }
 
 /*    for(var i=0, n=temp.length; i<n; i++) {
       var type = temp[i].getAttribute("type");*/
-    for(var i in temp) {
+    var storeVal;
+    var i;
+    for(i in temp) {
       if (results.responseXML) {
         if (!(temp.hasOwnProperty(i))) {
           continue;
         }
-        var type = temp[i].getAttribute("type");
-        var storeVal = temp[i].childNodes[0].nodeValue;
+        type = temp[i].getAttribute("type");
+        storeVal = temp[i].childNodes[0].nodeValue;
       } else if (results.responseJSON) {
-        var type = i;
-        var storeVal = temp[i];
+        type = i;
+        storeVal = temp[i];
       }
 
       switch (type) {<?php // the 'type' attribute defines what type of information is being provided ?>
@@ -421,7 +440,7 @@ objXHR.prototype.updSP = function () {
     var centre = document.getElementById("productGeneral");
     var temp = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
     var itemp = document.getElementById(_secondPrice);
-    var flag = false;
+    flag = false;
 
     if (objSP === false) { // create the second price object
       if (!temp || !itemp) {
@@ -440,13 +459,11 @@ objXHR.prototype.updSP = function () {
 <?php
 $show_dynamic_price_updater_sidebox = true;
 
-  if ($show_dynamic_price_updater_sidebox == true)
+  if ($show_dynamic_price_updater_sidebox === true)
   {
 ?>
-    objXHR.prototype.createSB = function ()
-    { // create the sidebox for the attributes info display
-      if (!(document.getElementById("dynamicpriceupdatersidebox")) && objSB)
-      {
+    objXHR.prototype.createSB = function () { // create the sidebox for the attributes info display
+      if (!(document.getElementById("dynamicpriceupdatersidebox")) && objSB) {
         var tempC = document.createElement("div");
         tempC.id = "dynamicpriceupdatersideboxContent";
         tempC.className = "sideBoxContent";
@@ -463,19 +480,21 @@ objXHR.prototype.showErrors = function () {
 //  var errorText = this.responseXML.getElementsByTagName("responseText");
   var alertText = "";
   var errVal;
+  var errorText;
+  var i;
 
-  if (typeof zcJS == "undefined" || !zcJS) {
-    var errorText = this.responseXML.getElementsByTagName("responseText");
+  if (typeof zcJS === "undefined" || !zcJS) {
+    errorText = this.responseXML.getElementsByTagName("responseText");
   } else {
-    var errorText = this.responseJSON.responseText;
+    errorText = this.responseJSON.responseText;
   }
   //var n=errorText.length;
 
-  for (var i in errorText/*var i=0; i<n; i++*/) {
+  for (i in errorText/*var i=0; i<n; i++*/) {
     if (!(errorText.hasOwnProperty(i))) {
       continue;
     }
-    if (typeof zcJS == "undefined" || !zcJS) {
+    if (typeof zcJS === "undefined" || !zcJS) {
       errVal = errorText[i].childNodes[0].nodeValue;
     } else {
       errVal = i;
@@ -489,31 +508,44 @@ var xhr = new objXHR;
 
 function init() {
   var n=document.forms.length;
-  for (var i=0; i<n; i++) {
-    if (document.forms[i].name == theFormName) {
+  var i;
+  for (i = 0; i < n; i += 1) {
+    if (document.forms[i].name === theFormName) {
       theForm = document.forms[i];
-      continue;
+      //continue; // Unnecessary though had originally thought of building more into this area.
     }
   }
 
-  var n=theForm.elements.length;
-  for (var i=0; i<n; i++) {
+  n=theForm.elements.length;
+  for (i = 0; i < n; i += 1) {
     switch (theForm.elements[i].type) {
       case "select":
       case "select-one":
-        theForm.elements[i].addEventListener("change", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("change", function () {
+          xhr.getPrice();
+        });
         break;
       case "text":
-        theForm.elements[i].addEventListener("keyup", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("keyup", function () {
+          xhr.getPrice();
+        });
         break;
       case "checkbox":
       case "radio":
-        theForm.elements[i].addEventListener("click", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("click", function () {
+          xhr.getPrice();
+        });
         break;
       case "number":
-        theForm.elements[i].addEventListener("change", function () { xhr.getPrice(); });
-        theForm.elements[i].addEventListener("keyup", function () { xhr.getPrice(); });
-        theForm.elements[i].addEventListener("input", function () { xhr.getPrice(); });
+        theForm.elements[i].addEventListener("change", function () {
+          xhr.getPrice();
+        });
+        theForm.elements[i].addEventListener("keyup", function () {
+          xhr.getPrice();
+        });
+        theForm.elements[i].addEventListener("input", function () {
+          xhr.getPrice();
+        });
         break;
     }
   }
@@ -521,7 +553,7 @@ function init() {
 <?php
   $show_dynamic_price_updater_sidebox = true;
 
-    if ($show_dynamic_price_updater_sidebox == true)
+    if ($show_dynamic_price_updater_sidebox === true)
     {
 ?>
     xhr.createSB();
@@ -529,7 +561,7 @@ function init() {
     }
 ?>
   xhr.getPrice();
-};
+}
 
 <?php
 // the following statements should allow multiple onload handlers to be applied

--- a/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
@@ -118,7 +118,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
         }
       };
 
-      this.XHR.open(strMode.toLowerCase(), "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
+      this.XHR.open(strMode.toLowerCase(), "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params(array('action','pid')) . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>" + (strMode.toLowerCase() === "get" ? "&" + this.compileRequest() : ""), true);
    
 /*                        this.XHR.open(strMode.toLowerCase(), this.url+"?act=DPU_Ajax&method=dpu_update"+(strMode.toLowerCase() == "get" ? "&" + this.compileRequest() : ""), true);*/
       if (strMode.toLowerCase() === "post") {
@@ -128,7 +128,7 @@ objXHR.prototype.getData = function(strMode, resFunc, combinedData) { // send a 
       this.XHR.send(combinedData.XML);
     } else {
       var option = {
-          url: "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params() . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>",
+          url: "<?php echo zen_decode_specialchars(zen_href_link('ajax.php', zen_get_all_get_params(array('action','pid')) . 'act=DPU_Ajax&method=dpu_update', $request_type, true, true, true)); ?>",
                     data: combinedData.JSON,
                      timeout : 30000
                    };

--- a/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
+++ b/Installation files/includes/modules/pages/product_music_info/jscript_dynamic_price_updater.php
@@ -204,9 +204,12 @@ objXHR.prototype.getPrice = function () {
     <?php if (DPU_SHOW_LOADING_IMAGE === 'true') { ?>
 
     var psp = false;
-    if (imgLoc === "replace") {
+//    if (imgLoc === "replace") {
       var thePrice = document.getElementById("<?php echo DPU_PRICE_ELEMENT_ID; ?>");
-      var test = thePrice.getElementsByTagName("span");
+      var test = false;
+      if (thePrice) {
+        test = thePrice.getElementsByTagName("span");
+      }
       var a;
       var b = test.length;
 
@@ -218,11 +221,15 @@ objXHR.prototype.getPrice = function () {
       if (!psp) {
         psp = thePrice;
       }
-    }
+      if (psp) {
+        pspClass = psp.className;
+        origPrice = psp.innerHTML;
+      }
+//  }
     if (psp && imgLoc === "replace") {
       if (thePrice) {
         loadImg.style.display = "inline"; //'block';
-        pspClass = psp.className;
+//        pspClass = psp.className;
         var pspStyle = psp.currentStyle || window.getComputedStyle(psp);
         loadImg.style.height = pspStyle.lineHeight; // Maintains the height so that there is not a vertical shift of the content.
         origPrice = psp.innerHTML;

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,43 @@
-Dynamic Price Updater v3.0.8
+Dynamic Price Updater v3.2.0
 -=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+3.2.0, What changed:
+- Identified this version as 3.2.0 because 1) this update provided significant new functionality and modified/provided
+    new database features and 2) 3.1.0 had previously been identified in the github path/history and did not want to
+    cause undo confusion.
+- Commented out code that performed no operation/action.
+- Added an update to the customer's latest page when using an ajax style call to improve display of
+    information on the who's online admin page.
+- Added a method to update price text to represent when none and less than all attributes have been selected.
+- Added DPU_ATTRIBUTES_MULTI_PRICE_TEXT to be able to control which of the pretext(s) to allow to show.
+- Added a variable to be able to update/display the text before the first price when price includes
+    a special and/or a sale.
+- Added ability to update what is known as the normalprice which is the price/value that is crossed out when there
+    is a sale or other special.
+- Added stock quantity update capability which incorporates the possibility of operating with ZC 1.5.x and
+    control how the information is replaces other content.  Guidance for display modifications provided in readme.txt.
+- Corrected use of float casting to use code published in ZC 1.5.6 to support strict server mode.
+- Reworked code to better account and control sub-functional area execution.
+- Removed single quotes from SQL queries that included casted integers to minimize further processing.
+- Expanded attribute text switching to more than product priced by attribute such that should apply to
+    product that have attributes that affect the base price.
+- Corrected price display and determination to include pricing associated with text (word and/or letter pricing, etc...)
+- Updated javascript side to use exactly equal to instead of loosely comparing two values (in a majority of examples.
+- Switched javascript calls to use dot notation where able.
+- Added a fallback attempt for collecting/setting JSON response if responseJSON is empty but a non-fault responseText
+    is provided.
+- Moved javascript variable declaration out of most function calls.
+- Corrected an issue reported by mvstudio of where the expected text to be in front of the priced item would not be
+    displayed if the imgLoc variable in the includes/modules/pages/PRODUCT_TYPE/jscript_dynamic_price_updater.php file
+    was not set to "replace".  Essentially the result was that pspClass would be blank when sending to ajax.
+- Added change detection and capture of the html element textarea and changed the text detection to an input event
+    instead of a keyup event.  This allows capture/detection of pasted content without firing off multiple events for
+    the same modification.  Additional testing may reveal the need to incorporate other event listeners. The process
+    would be similar as shown for the number case.
+- Updated ajax.php file to prevent known spiders from performing ajax requests.  This is from the ZC 1.5.6 version of
+    the file
+- Moved the status notification from an alert to a console log when zcJS is not used and a 200 status result is not
+    received.
 
 3.0.8, What changed:
 - Added a switch and code to support deactivating the use of currency symbols
@@ -134,12 +172,24 @@ NOTE: If you have a version of Updater installed earlier than 3.0 please remove 
   includes/modules/pages/product_music_info/jscript_ajax_updater.php
   includes/modules/sideboxes/YOUR_TEMPLATE/dynamic_price_updater_sidebox.php
   includes/templates/YOUR_TEMPLATE/sideboxes/tpl_dynamic_price_updater_sidebox.php
+  includes/templates/YOUR_TEMPLATE/jscript/jscript_jquery.min.dpu.php
 
   dpu_ajax.php has been removed from the fileset as far as necessary code. After all files are in the place provided it may be removed from the server.
+  it is expected that to support use of the ZC zcJS ajax process, that includes/templates/YOUR_TEMPLATE/jscript/ contains
+    the file jscript_framework.php that can be found in includes/templates/template_default/jscript/
+  it is also expected that your template loads a version of jQuery preferably 1.12.0 or above. jscript_jquery.min.dpu.php is
+    provided to remotely load jQuery 1.12.4 if a form of jQuery has not yet been loaded when the file is executed.
 
 4. Log in to your webshop's admin panel, and the module will install automatically. There are no seperate sql files needed.
 5. Installation is now complete.
 6. By default DPU is disabled. Go to configuration=>Dynamic Price Updater set the status to true to enable DPU
+7. To allow DPU to update the display of product quantity available (in particular if using Stock By Attributes):
+   7.a. edit includes/templates/YOUR_TEMPLATE/templates/tpl_product_info_display.php with a plain text editor.
+   7.b. find: 
+$products_quantity . 
+   7.c. and surround it by a span tag (replace with below) so that it will look like: 
+'<span id="productDetailsList_product_info_quantity">' . $products_quantity . '</span>' . 
+   7.d. perform the same for each PRODUCT_TYPE file such as product_music_info, etc...
 
 NOTE: If you have a version of Updater installed earlier than 3.0 please remove the files first
 
@@ -149,9 +199,9 @@ Settings
 
 The module is now set through the admin, more instructions to be added later
 
-As of Version 3.0.6 the settings include the following configuration options
+As of Version 3.2.0 the settings include the following configuration options
 Dynamic Price Updater Status 	true - Allow disabling DPU in whole
-Dynamic Price Updater Version 	3.0.6 - Radio button style presentation of installed version
+Dynamic Price Updater Version 	3.2.0 - Radio button style presentation of installed version
 Dynamic Price Updater Version Check? 	true - Allow DPU to check for latest ZC issued version?
 Where to display the price 	productPrices - Class in which DPU prices are to be shown/updated
 Define used to set a variable for this script 	cart_quantity - Value of name field for form that contains attributes and quantities.
@@ -160,6 +210,11 @@ show a small loading graphic 	true - While data is being retrieved from the syst
 Show currency symbols 	true - If desired to see the symbols ($) associated with the customer's chosen currency then choose true.
 Show product quantity 	false - This is the quantity of the specifically selected/entered combination of attributes that are in the cart.
 Where to display the second price cartAdd - This is the id of the location to display the calculated price as a second location.
+Show sidebox currency symbols 	true - Show currency symbols in the sidebox (when displayed).
+Show alternate text for partial selection 	start_at_least 	 When selections are being made that affect the price of the product, what alternate text if any should be shown to the customer.  For example if when no selections have been made, the ZC starting at text may be displayed.  When one selection of many has been made, then the text may be changed to at least this amount indicating that there are selections to be made that could increase the price.  Then once all selections have been made as expected/required the text is or should change to something like Your Price:.
+Show or update the display of out-of-stock 	quantity_replace 	Allows display of the current stock status of a product while the customer remains on the product information page and offers control about the ajax update when the product is identified as out-of-stock.
+Modify minimum attribute display price 	all 	On what should the minimum display price be based for product with attributes? Only product that are priced by attribute or for all product that have attributes?
+The id tag for product_quantity 	productDetailsList_product_info_quantity 	This is the ID where your product quantity is displayed.
 
 Support
 -------
@@ -171,7 +226,14 @@ http://www.zen-cart.com/forum/showthread.php?t=70577
 Credits
 -------
 
-Versions 3.0.5 and 3.0.6 brought to you by mc12345678: http://mc12345678.com
+Version 3.2.0 brought to you by mc12345678: http://mc12345678.com with thank yous to:
+  mvstudio for identifying issues with strict operation, as well as edge case operation.
+  izar74 for a potential way to display out-of-stock information.
+  diamond1 for identifying the need of these instructions to contain just a little more.
+  Calljj for the idea of updating the "base" price while making attribute selections on product
+    that are on special or on sale.  This allows seeing the true price reduction/difference for chosen options.
+
+Versions 3.0.5 through 3.0.8 brought to you by mc12345678: http://mc12345678.com
 
 This update (V3.0.4 base content) : Erik Kerkhoven (Design75) http://zen4all.nl brought by mc12345678: http://mc12345678.com
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,43 @@
-Dynamic Price Updater v3.0.8
+Dynamic Price Updater v3.2.0
 -=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+3.2.0, What changed:
+- Identified this version as 3.2.0 because 1) this update provided significant new functionality and modified/provided
+    new database features and 2) 3.1.0 had previously been identified in the github path/history and did not want to
+    cause undo confusion.
+- Commented out code that performed no operation/action.
+- Added an update to the customer's latest page when using an ajax style call to improve display of
+    information on the who's online admin page.
+- Added a method to update price text to represent when none and less than all attributes have been selected.
+- Added DPU_ATTRIBUTES_MULTI_PRICE_TEXT to be able to control which of the pretext(s) to allow to show.
+- Added a variable to be able to update/display the text before the first price when price includes
+    a special and/or a sale.
+- Added ability to update what is known as the normalprice which is the price/value that is crossed out when there
+    is a sale or other special.
+- Added stock quantity update capability which incorporates the possibility of operating with ZC 1.5.x and
+    control how the information is replaces other content.  Guidance for display modifications provided in readme.txt.
+- Corrected use of float casting to use code published in ZC 1.5.6 to support strict server mode.
+- Reworked code to better account and control sub-functional area execution.
+- Removed single quotes from SQL queries that included casted integers to minimize further processing.
+- Expanded attribute text switching to more than product priced by attribute such that should apply to
+    product that have attributes that affect the base price.
+- Corrected price display and determination to include pricing associated with text (word and/or letter pricing, etc...)
+- Updated javascript side to use exactly equal to instead of loosely comparing two values (in a majority of examples.
+- Switched javascript calls to use dot notation where able.
+- Added a fallback attempt for collecting/setting JSON response if responseJSON is empty but a non-fault responseText
+    is provided.
+- Moved javascript variable declaration out of most function calls.
+- Corrected an issue reported by mvstudio of where the expected text to be in front of the priced item would not be
+    displayed if the imgLoc variable in the includes/modules/pages/PRODUCT_TYPE/jscript_dynamic_price_updater.php file
+    was not set to "replace".  Essentially the result was that pspClass would be blank when sending to ajax.
+- Added change detection and capture of the html element textarea and changed the text detection to an input event
+    instead of a keyup event.  This allows capture/detection of pasted content without firing off multiple events for
+    the same modification.  Additional testing may reveal the need to incorporate other event listeners. The process
+    would be similar as shown for the number case.
+- Updated ajax.php file to prevent known spiders from performing ajax requests.  This is from the ZC 1.5.6 version of
+    the file
+- Moved the status notification from an alert to a console log when zcJS is not used and a 200 status result is not
+    received.
 
 3.0.8, What changed:
 - Added a switch and code to support deactivating the use of currency symbols
@@ -134,8 +172,13 @@ NOTE: If you have a version of Updater installed earlier than 3.0 please remove 
   includes/modules/pages/product_music_info/jscript_ajax_updater.php
   includes/modules/sideboxes/YOUR_TEMPLATE/dynamic_price_updater_sidebox.php
   includes/templates/YOUR_TEMPLATE/sideboxes/tpl_dynamic_price_updater_sidebox.php
+  includes/templates/YOUR_TEMPLATE/jscript/jscript_jquery.min.dpu.php
 
   dpu_ajax.php has been removed from the fileset as far as necessary code. After all files are in the place provided it may be removed from the server.
+  it is expected that to support use of the ZC zcJS ajax process, that includes/templates/YOUR_TEMPLATE/jscript/ contains
+    the file jscript_framework.php that can be found in includes/templates/template_default/jscript/
+  it is also expected that your template loads a version of jQuery preferably 1.12.0 or above. jscript_jquery.min.dpu.php is
+    provided to remotely load jQuery 1.12.4 if a form of jQuery has not yet been loaded when the file is executed.
 
 4. Log in to your webshop's admin panel, and the module will install automatically. There are no seperate sql files needed.
 5. Installation is now complete.
@@ -156,9 +199,9 @@ Settings
 
 The module is now set through the admin, more instructions to be added later
 
-As of Version 3.0.6 the settings include the following configuration options
+As of Version 3.2.0 the settings include the following configuration options
 Dynamic Price Updater Status 	true - Allow disabling DPU in whole
-Dynamic Price Updater Version 	3.0.6 - Radio button style presentation of installed version
+Dynamic Price Updater Version 	3.2.0 - Radio button style presentation of installed version
 Dynamic Price Updater Version Check? 	true - Allow DPU to check for latest ZC issued version?
 Where to display the price 	productPrices - Class in which DPU prices are to be shown/updated
 Define used to set a variable for this script 	cart_quantity - Value of name field for form that contains attributes and quantities.
@@ -167,6 +210,11 @@ show a small loading graphic 	true - While data is being retrieved from the syst
 Show currency symbols 	true - If desired to see the symbols ($) associated with the customer's chosen currency then choose true.
 Show product quantity 	false - This is the quantity of the specifically selected/entered combination of attributes that are in the cart.
 Where to display the second price cartAdd - This is the id of the location to display the calculated price as a second location.
+Show sidebox currency symbols 	true - Show currency symbols in the sidebox (when displayed).
+Show alternate text for partial selection 	start_at_least 	 When selections are being made that affect the price of the product, what alternate text if any should be shown to the customer.  For example if when no selections have been made, the ZC starting at text may be displayed.  When one selection of many has been made, then the text may be changed to at least this amount indicating that there are selections to be made that could increase the price.  Then once all selections have been made as expected/required the text is or should change to something like Your Price:.
+Show or update the display of out-of-stock 	quantity_replace 	Allows display of the current stock status of a product while the customer remains on the product information page and offers control about the ajax update when the product is identified as out-of-stock.
+Modify minimum attribute display price 	all 	On what should the minimum display price be based for product with attributes? Only product that are priced by attribute or for all product that have attributes?
+The id tag for product_quantity 	productDetailsList_product_info_quantity 	This is the ID where your product quantity is displayed.
 
 Support
 -------
@@ -178,7 +226,14 @@ http://www.zen-cart.com/forum/showthread.php?t=70577
 Credits
 -------
 
-Versions 3.0.5 and 3.0.6 brought to you by mc12345678: http://mc12345678.com
+Version 3.2.0 brought to you by mc12345678: http://mc12345678.com with thank yous to:
+  mvstudio for identifying issues with strict operation, as well as edge case operation.
+  izar74 for a potential way to display out-of-stock information.
+  diamond1 for identifying the need of these instructions to contain just a little more.
+  Calljj for the idea of updating the "base" price while making attribute selections on product
+    that are on special or on sale.  This allows seeing the true price reduction/difference for chosen options.
+
+Versions 3.0.5 through 3.0.8 brought to you by mc12345678: http://mc12345678.com
 
 This update (V3.0.4 base content) : Erik Kerkhoven (Design75) http://zen4all.nl brought by mc12345678: http://mc12345678.com
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,13 @@ NOTE: If you have a version of Updater installed earlier than 3.0 please remove 
 4. Log in to your webshop's admin panel, and the module will install automatically. There are no seperate sql files needed.
 5. Installation is now complete.
 6. By default DPU is disabled. Go to configuration=>Dynamic Price Updater set the status to true to enable DPU
+7. To allow DPU to update the display of product quantity available (in particular if using Stock By Attributes):
+   7.a. edit includes/templates/YOUR_TEMPLATE/templates/tpl_product_info_display.php with a plain text editor.
+   7.b. find: 
+$products_quantity . 
+   7.c. and surround it by a span tag (replace with below) so that it will look like: 
+'<span id="productDetailsList_product_info_quantity">' . $products_quantity . '</span>' . 
+   7.d. perform the same for each PRODUCT_TYPE file such as product_music_info, etc...
 
 NOTE: If you have a version of Updater installed earlier than 3.0 please remove the files first
 


### PR DESCRIPTION
3.2.0, What changed:
- Identified this version as 3.2.0 because 1) this update provided significant new functionality and modified/provided new database features and 2) 3.1.0 had previously been identified in the github path/history and did not want to cause undo confusion.
- Commented out code that performed no operation/action.
- Added an update to the customer's latest page when using an ajax style call to improve display of information on the who's online admin page.
- Added a method to update price text to represent when none and less than all attributes have been selected.
- Added DPU_ATTRIBUTES_MULTI_PRICE_TEXT to be able to control which of the pretext(s) to allow to show.
- Added a variable to be able to update/display the text before the first price when price includes a special and/or a sale.
- Added ability to update what is known as the normalprice which is the price/value that is crossed out when there is a sale or other special.
- Added stock quantity update capability which incorporates the possibility of operating with ZC 1.5.x and control how the information replaces other content.  Guidance for display modifications provided in readme.txt.
- Corrected use of float casting to use code published in ZC 1.5.6 to support strict server mode.
- Reworked code to better account and control sub-functional area execution.
- Removed single quotes from SQL queries that included casted integers to minimize further processing.
- Expanded attribute text switching to more than product priced by attribute such that should apply to product that have attributes that affect the base price.
- Corrected price display and determination to include pricing associated with text (word and/or letter pricing, etc...)
- Updated javascript side to use exactly equal to instead of loosely comparing two values (in a majority of examples).
- Switched javascript calls to use dot notation where able.
- Added a fallback attempt for collecting/setting JSON response if responseJSON is empty but a non-fault responseText is provided.
- Moved javascript variable declaration out of most function calls.
- Corrected an issue reported by mvstudio of where the expected text to be in front of the priced item would not be displayed if the imgLoc variable in the includes/modules/pages/PRODUCT_TYPE/jscript_dynamic_price_updater.php file was not set to "replace".  Essentially the result was that pspClass would be blank when sending to ajax.
- Added change detection and capture of the html element textarea and changed the text detection to an input event instead of a keyup event.  This allows capture/detection of pasted content without firing off multiple events for the same modification.  Additional testing may reveal the need to incorporate other event listeners. The process would be similar as shown for the number case.
- Updated ajax.php file to prevent known spiders from performing ajax requests.  This is from the ZC 1.5.6 version of the file
- Moved the status notification from an alert to a console log when zcJS is not used and a 200 status result is not received.